### PR TITLE
Fix bug in postgres credentials escaping with special characters

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"inviqa/kafka-outbox-relay/log"
+	"net/url"
 	"time"
 
 	"github.com/alexflint/go-arg"


### PR DESCRIPTION
URLs need each component url escaping. Particularly where their components can support characters that split the components up (such as ?, @ and : ).

This is most affected with some password generators when special characters are used.

The MySQL driver seems unaffected by it, and breaks if done correctly