### PR TITLE
Make initial migration more friendly to those migrating from old outbox

### DIFF
--- a/outbox/data/migrations/postgres/20210422155457_create_kafka_outbox.up.sql
+++ b/outbox/data/migrations/postgres/20210422155457_create_kafka_outbox.up.sql
@@ -12,4 +12,4 @@ CREATE TABLE IF NOT EXISTS kafka_outbox(
     created_at timestamp DEFAULT CURRENT_TIMESTAMP
 );
 
-CREATE INDEX outbox_push_completed_at ON kafka_outbox(push_completed_at);
+CREATE INDEX IF NOT EXISTS outbox_push_completed_at ON kafka_outbox(push_completed_at);


### PR DESCRIPTION
Some of our more recent project services had this constraint in place already, but the migrations were failing when switching over to this image from the project-specific ones due to this SQL statement not handling this case.