### PR TITLE
Respect the original order that messages were created

### DIFF
--- a/outbox/data/sql/mysql_provider.go
+++ b/outbox/data/sql/mysql_provider.go
@@ -25,13 +25,13 @@ func (m MysqlQueryProvider) MessageErroredUpdateSql(maxPushAttempts int) string 
 func (m MysqlQueryProvider) BatchCreationSql(batchSize int) string {
 	q := `UPDATE %s SET batch_id = ?, push_started_at = NOW()
 		WHERE ((batch_id IS NULL AND push_started_at IS NULL) OR
-		(batch_id IS NOT NULL AND push_completed_at IS NULL AND push_started_at < ?)) AND errored = ? LIMIT %d`
+		(batch_id IS NOT NULL AND push_completed_at IS NULL AND push_started_at < ?)) AND errored = ? ORDERED BY created_at ASC LIMIT %d`
 
 	return fmt.Sprintf(q, m.Table, batchSize)
 }
 
 func (m MysqlQueryProvider) BatchFetchSql() string {
-	return fmt.Sprintf(`SELECT %s FROM %s WHERE batch_id = ?`, strings.Join(m.escapeColumns(), ", "), m.Table)
+	return fmt.Sprintf(`SELECT %s FROM %s WHERE batch_id = ? ORDERED BY created_at ASC`, strings.Join(m.escapeColumns(), ", "), m.Table)
 }
 
 func (m MysqlQueryProvider) DeletePublishedMessagesSql() string {

--- a/outbox/data/sql/mysql_provider.go
+++ b/outbox/data/sql/mysql_provider.go
@@ -25,13 +25,13 @@ func (m MysqlQueryProvider) MessageErroredUpdateSql(maxPushAttempts int) string 
 func (m MysqlQueryProvider) BatchCreationSql(batchSize int) string {
 	q := `UPDATE %s SET batch_id = ?, push_started_at = NOW()
 		WHERE ((batch_id IS NULL AND push_started_at IS NULL) OR
-		(batch_id IS NOT NULL AND push_completed_at IS NULL AND push_started_at < ?)) AND errored = ? ORDERED BY created_at ASC LIMIT %d`
+		(batch_id IS NOT NULL AND push_completed_at IS NULL AND push_started_at < ?)) AND errored = ? ORDER BY created_at ASC LIMIT %d`
 
 	return fmt.Sprintf(q, m.Table, batchSize)
 }
 
 func (m MysqlQueryProvider) BatchFetchSql() string {
-	return fmt.Sprintf(`SELECT %s FROM %s WHERE batch_id = ? ORDERED BY created_at ASC`, strings.Join(m.escapeColumns(), ", "), m.Table)
+	return fmt.Sprintf(`SELECT %s FROM %s WHERE batch_id = ? ORDER BY created_at ASC`, strings.Join(m.escapeColumns(), ", "), m.Table)
 }
 
 func (m MysqlQueryProvider) DeletePublishedMessagesSql() string {

--- a/outbox/data/sql/mysql_provider_test.go
+++ b/outbox/data/sql/mysql_provider_test.go
@@ -41,7 +41,7 @@ func TestMysqlQueryProvider_DeletePublishedMessagesSql(t *testing.T) {
 
 func TestMysqlQueryProvider_BatchFetchSql(t *testing.T) {
 	got := createProvider().BatchFetchSql()
-	exp := "SELECT `name`, `foo` FROM kafka_outbox WHERE batch_id = ? ORDERED BY created_at ASC"
+	exp := "SELECT `name`, `foo` FROM kafka_outbox WHERE batch_id = ? ORDER BY created_at ASC"
 
 	if got != exp {
 		t.Errorf("expected '%s', but got '%s'", exp, got)

--- a/outbox/data/sql/mysql_provider_test.go
+++ b/outbox/data/sql/mysql_provider_test.go
@@ -41,7 +41,7 @@ func TestMysqlQueryProvider_DeletePublishedMessagesSql(t *testing.T) {
 
 func TestMysqlQueryProvider_BatchFetchSql(t *testing.T) {
 	got := createProvider().BatchFetchSql()
-	exp := "SELECT `name`, `foo` FROM kafka_outbox WHERE batch_id = ?"
+	exp := "SELECT `name`, `foo` FROM kafka_outbox WHERE batch_id = ? ORDERED BY created_at ASC"
 
 	if got != exp {
 		t.Errorf("expected '%s', but got '%s'", exp, got)

--- a/outbox/data/sql/postgres_provider.go
+++ b/outbox/data/sql/postgres_provider.go
@@ -31,13 +31,13 @@ func (m PostgresQueryProvider) BatchCreationSql(batchSize int) string {
 	q := `UPDATE %s SET batch_id = $1, push_started_at = NOW()
 		WHERE id IN(
 			SELECT id FROM %s WHERE ((batch_id IS NULL AND push_started_at IS NULL) OR
-		(batch_id IS NOT NULL AND push_completed_at IS NULL AND push_started_at < $2)) AND errored = $3 LIMIT %d)`
+		(batch_id IS NOT NULL AND push_completed_at IS NULL AND push_started_at < $2)) AND errored = $3 ORDERED BY created_at ASC LIMIT %d)`
 
 	return fmt.Sprintf(q, m.Table, m.Table, batchSize)
 }
 
 func (m PostgresQueryProvider) BatchFetchSql() string {
-	return fmt.Sprintf(`SELECT %s FROM %s WHERE batch_id = $1`, strings.Join(m.Columns, ", "), m.Table)
+	return fmt.Sprintf(`SELECT %s FROM %s WHERE batch_id = $1 ORDERED BY created_at ASC`, strings.Join(m.Columns, ", "), m.Table)
 }
 
 func (m PostgresQueryProvider) DeletePublishedMessagesSql() string {

--- a/outbox/data/sql/postgres_provider.go
+++ b/outbox/data/sql/postgres_provider.go
@@ -31,13 +31,13 @@ func (m PostgresQueryProvider) BatchCreationSql(batchSize int) string {
 	q := `UPDATE %s SET batch_id = $1, push_started_at = NOW()
 		WHERE id IN(
 			SELECT id FROM %s WHERE ((batch_id IS NULL AND push_started_at IS NULL) OR
-		(batch_id IS NOT NULL AND push_completed_at IS NULL AND push_started_at < $2)) AND errored = $3 ORDERED BY created_at ASC LIMIT %d)`
+		(batch_id IS NOT NULL AND push_completed_at IS NULL AND push_started_at < $2)) AND errored = $3 ORDER BY created_at ASC LIMIT %d)`
 
 	return fmt.Sprintf(q, m.Table, m.Table, batchSize)
 }
 
 func (m PostgresQueryProvider) BatchFetchSql() string {
-	return fmt.Sprintf(`SELECT %s FROM %s WHERE batch_id = $1 ORDERED BY created_at ASC`, strings.Join(m.Columns, ", "), m.Table)
+	return fmt.Sprintf(`SELECT %s FROM %s WHERE batch_id = $1 ORDER BY created_at ASC`, strings.Join(m.Columns, ", "), m.Table)
 }
 
 func (m PostgresQueryProvider) DeletePublishedMessagesSql() string {


### PR DESCRIPTION
Ordering by `created_at` in ascending order should accurately reflect the order in which the messages were created in the outbox tables. We had seen instances where this ordering has not been respected.