### PR TITLE
Create a batch query index to solve performance issues

### DIFF
--- a/outbox/data/migrations/mysql/20220408111504_batch_index.down.sql
+++ b/outbox/data/migrations/mysql/20220408111504_batch_index.down.sql
@@ -1,0 +1,1 @@
+DELETE INDEX outbox_batch_query;

--- a/outbox/data/migrations/mysql/20220408111504_batch_index.up.sql
+++ b/outbox/data/migrations/mysql/20220408111504_batch_index.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX outbox_batch_query ON kafka_outbox(batch_id, created_at);

--- a/outbox/data/migrations/postgres/20220408111504_batch_index.down.sql
+++ b/outbox/data/migrations/postgres/20220408111504_batch_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS outbox_batch_query;

--- a/outbox/data/migrations/postgres/20220408111504_batch_index.up.sql
+++ b/outbox/data/migrations/postgres/20220408111504_batch_index.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS outbox_batch_query ON kafka_outbox(batch_id, created_at);


### PR DESCRIPTION
There was no batch_id index before, so fetching batches at least in MySQL was a `Using where; Using filesort`